### PR TITLE
Custom configuration file support via new `USE_CUSTOM_CONFIG` env

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,17 @@ docker run --rm -it \
 FROM joseluisq/alpine-cgit
 ```
 
-## Volumes
+## Key container paths
 
-- `/srv/git`: Place for Git repositories.
-- `/var/cache/cgit`: CGit caching of generated HTML.
+- `/etc/cgitrc`: Default CGit configuration file.
+- `/srv/git`: Default directory for Git repositories scanned by CGit.
+- `/var/cache/cgit`: Default CGit caching directory of generated HTML.
 
-## Settings via env variables
+Note that all these paths can be overwritten via [Bind Mounts](https://docs.docker.com/storage/bind-mounts/) or [Docker Volumes](https://docs.docker.com/storage/volumes/).
+
+## Settings via environment variables
+
+CGit Docker image can be configured via environment variables. This is the default behaviour.
 
 - `CGIT_TITLE`: Website title.
 - `CGIT_DESC`: Website description.
@@ -52,7 +57,19 @@ FROM joseluisq/alpine-cgit
 - `CGIT_SECTION_FROM_STARTPATH`: How many path elements from each repo path to use as a default section name.
 - `CGIT_MAX_REPO_COUNT`: Number of entries to list per page on the repository index page.
 
-See default file configuration at [cgit/cgit.conf](./cgit/cgit.conf)
+## Settings via custom configration file
+
+By default this Docker image will use a template file located at [cgit/cgit.conf](./cgit/cgit.conf) which is replaced with the env settings (mentioned above) at start up time.
+
+However if you want to use a custom `/etc/cgitrc` file then follow these steps:
+
+1. Provide the env variable `USE_CUSTOM_CONFIG=true` to prevent using the default config file.
+2. Provide the custom config file as a [Bind Mount](https://docs.docker.com/storage/bind-mounts/) or [Docker Volume](https://docs.docker.com/storage/volumes/). For example `--volume my-config-file:/etc/cgitrc`
+3. Provide the `cache-root` option in your config file. For example `cache-root=/var/cache/cgit`
+4. Provide the `scan-path` option in your config file. For example `scan-path=/srv/git`
+5. Provide the repositories folder as a [Bind Mount](https://docs.docker.com/storage/bind-mounts/) or [Docker Volume](https://docs.docker.com/storage/volumes/). For example `--volume my-repos:/srv/git`
+
+See [`cgitrc` man page](https://linux.die.net/man/5/cgitrc) for more detailed information.
 
 ## Contributions
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -e
+
+# Check for incomming Nginx server commands or subcommands only
+if [ "$1" = "nginx" ] || [ "${1#-}" != "$1" ]; then
+    if [ "${1#-}" != "$1" ]; then
+        set -- nginx "$@"
+    fi
+
+    chown nginx:nginx /var/cache/cgit
+    chmod u+g /var/cache/cgit
+
+    # Replace environment variables only if `USE_CUSTOM_CONFIG` is not defined or equal to `false`
+    if [[ -z "$USE_CUSTOM_CONFIG" ]] || [[ "$USE_CUSTOM_CONFIG" = "false" ]]; then
+        envsubst < /tmp/cgitrc.tmpl > /etc/cgitrc
+    fi
+
+    spawn-fcgi \
+        -u nginx -g nginx \
+        -s /var/run/fcgiwrap.sock \
+        -n -- /usr/bin/fcgiwrap \
+        & exec "$@"
+else
+    exec "$@"
+fi


### PR DESCRIPTION
This PR provides a new `USE_CUSTOM_CONFIG` environment variable to prevent using the default `/etc/cgitrc` provided by this Docker image.

It also includes proper documentation to describe its usage.

Resolves #7.