### PR TITLE
add support for about page generation with groff and reStructuredText

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,8 @@ RUN set -eux \
         lua5.3-libs \
         py3-markdown \
         py3-pygments \
+        py3-docutils \
+        groff \
         python3 \
         spawn-fcgi \
         tzdata \


### PR DESCRIPTION
https://wiki.archlinux.org/title/Cgit#Formatting_the_about_page

cgit can generate about pages from manpages and reStructuredText formats in addition to markdown if you simply make groff available for manpages and py3-docutils for reStructuredText. See above arch wiki link. I use this to generate an about from a manpage rather than write a separate readme.md etc